### PR TITLE
Posts from followed

### DIFF
--- a/src/components/home/FeedChoice.js
+++ b/src/components/home/FeedChoice.js
@@ -1,0 +1,45 @@
+import { useEffect } from "react"
+
+
+export const FeedChoice = ({ recipes, display, setDisplay, updateRecipesToDisplay, usersFollows }) => {
+
+    useEffect(
+        () => {
+            if (display === "allPosts") {
+                updateRecipesToDisplay(recipes)
+            }
+
+            if (display === "postsFollowed") {
+                const postsFromUsersFollowed = recipes.filter(
+                    recipe => usersFollows.some(followObj => followObj.whoIsFollowed === recipe.userId))
+                updateRecipesToDisplay(postsFromUsersFollowed)
+            }
+        },
+        [recipes, display, usersFollows]
+    )
+
+
+    return <>
+        <input
+            type="radio"
+            name="feedChoiceInterface"
+            value="allPosts"
+            checked={display === "allPosts"}
+            onChange={() => {
+                setDisplay("allPosts")
+            }}
+        />
+        <span>Discover</span>
+
+        <input
+            type="radio"
+            name="feedChoiceInterface"
+            value="postsFollowed"
+            checked={display === "postsFollowed"}
+            onChange={() => {
+                setDisplay("postsFollowed")
+            }}
+        />
+        <span>My Feed</span>
+    </>
+}

--- a/src/components/home/FilterBar.js
+++ b/src/components/home/FilterBar.js
@@ -1,7 +1,7 @@
 import { SearchRecipes } from "./SearchRecipes";
 import { FilterByCategories } from "./FilterByCategories";
 
-export const FilterBar = ({ searchTerms, updateSearchTerms, setFilteredRecipes, recipes, onlyRecipesWithTags, updateOnlyRecipesWithTags, onlySearchedRecipes, updateOnlySearchedRecipes }) => {
+export const FilterBar = ({ searchTerms, updateSearchTerms, setFilteredRecipes, recipes, onlyRecipesWithTags, updateOnlyRecipesWithTags, onlySearchedRecipes, updateOnlySearchedRecipes, chosenCategories, updateChosenCategories }) => {
 
     return <> 
         <section className="filterBar">
@@ -11,14 +11,17 @@ export const FilterBar = ({ searchTerms, updateSearchTerms, setFilteredRecipes, 
             onlyRecipesWithTags={onlyRecipesWithTags}
             updateOnlySearchedRecipes={updateOnlySearchedRecipes}
             setFilteredRecipes={setFilteredRecipes}
-            updateSearchTerms={updateSearchTerms}/>
+            updateSearchTerms={updateSearchTerms}
+            chosenCategories={chosenCategories} />
 
             <FilterByCategories
             recipes={recipes}
             searchTerms={searchTerms}
             updateOnlyRecipesWithTags={updateOnlyRecipesWithTags}
             setFilteredRecipes={setFilteredRecipes}
-            onlySearchedRecipes={onlySearchedRecipes} />
+            onlySearchedRecipes={onlySearchedRecipes}
+            chosenCategories={chosenCategories}
+            updateChosenCategories={updateChosenCategories} />
         </section>
     </>
 }

--- a/src/components/home/FilterByCategories.js
+++ b/src/components/home/FilterByCategories.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react"
 import Select from 'react-select';
 
-export const FilterByCategories = ({ recipes, searchTerms, updateOnlyRecipesWithTags, setFilteredRecipes, onlySearchedRecipes}) => {
+export const FilterByCategories = ({ recipes, searchTerms, updateOnlyRecipesWithTags, setFilteredRecipes, onlySearchedRecipes, chosenCategories, updateChosenCategories}) => {
     // Define a state variable for fetched categories
     const [categories, setCategories] = useState([])
     // State variable for different types of categories 
@@ -10,8 +10,7 @@ export const FilterByCategories = ({ recipes, searchTerms, updateOnlyRecipesWith
     const [chosenCategoryType, updateChosenCategoryType] = useState("")
     // State variable for which category options to display based on chosenCategoryType
     const [filteredCategories, setFilteredCategories] = useState([])
-    // State to keep track of all selected categories the user wants to use to filter recipe feed
-    const [chosenCategories, updateChosenCategories] = useState([])
+    
 
     // Fetch the list of categories
     const fetchCategories = () => {
@@ -101,7 +100,7 @@ export const FilterByCategories = ({ recipes, searchTerms, updateOnlyRecipesWith
                 setFilteredRecipes(recipes)
             }
         },
-        [chosenCategories]
+        [chosenCategories, recipes, onlySearchedRecipes]
     )
 
     // Handle the selected category

--- a/src/components/home/Home.js
+++ b/src/components/home/Home.js
@@ -2,21 +2,43 @@ import { useEffect, useState } from "react"
 import { useNavigate } from "react-router-dom"
 import { RecipeFeed } from "./RecipeFeed"
 import { FilterBar } from "./FilterBar"
+import { FeedChoice } from "./FeedChoice"
 
 
 export const Home = () => {
-    const [recipes, setRecipes] = useState([]) // Observing initial state []
-    const [filteredRecipes, setFilteredRecipes] = useState([])
-    const [searchTerms, updateSearchTerms] = useState("")
-
-    // Define additional state variables to allow users to stack filtering options
-    const [onlyRecipesWithTags, updateOnlyRecipesWithTags] = useState([])
-    const [onlySearchedRecipes, updateOnlySearchedRecipes] = useState([])
-
     // Get the current user
     const localGastroUser = localStorage.getItem("gastro_user")
     const gastroUserObject = JSON.parse(localGastroUser)
 
+    // State for all recipes
+    const [recipes, setRecipes] = useState([]) // Observing initial state []
+
+    /* State for which posts to display at the broadest level. User can choose
+       'discover', which shows all posts, or 'my feed' which shows posts from 
+       only users the current user is 'following' */
+    const [display, setDisplay] = useState("allPosts") 
+    // State for recipes that will be displayed based on users selection of display
+    const [recipesToDisplay, updateRecipesToDisplay] = useState([])
+    // State for recipes filtered by either searching or filtering by category
+
+    /*--FILTER-OPTIONS--------------------------------------------------------------------------*/ 
+    // State to allow recipes to be filtered by search query or by selected category tag
+    const [filteredRecipes, setFilteredRecipes] = useState([])
+    // State to track user input in search bar
+    const [searchTerms, updateSearchTerms] = useState("")
+    // State to keep track of all selected categories the user wants to use to filter recipe feed
+    const [chosenCategories, updateChosenCategories] = useState([])
+
+    /*  Define additional state variables to allow users to stack and unstack filtering options.
+        Once the 'recipesToDisplay' is set, separate state will be preserved for filtering by search
+        query and filtering by category tag. This will allow the user remove their search and still
+        view filtered recipes based on category, or remove the selected category filters and still
+        view results based on their search. */
+    const [onlyRecipesWithTags, updateOnlyRecipesWithTags] = useState([])
+    const [onlySearchedRecipes, updateOnlySearchedRecipes] = useState([])
+    /*-------------------------------------------------------------------------------------------*/
+
+    /*---------------------------------------------------------------------------------------------------------*/
     // Fetch the list of recipes with user info expanded and ingredients and categories embedded
     const fetchRecipes = () => {
         fetch(`http://localhost:8088/recipeCards?_expand=user&_embed=ingredientsInRecipes&_embed=categoriesOfRecipes`)
@@ -31,38 +53,83 @@ export const Home = () => {
         },
         [] // When this array is empty, you are observing initial component state
     )
-
-    // Set the filtered recipes to default upon initial render
+    /*---------------------------------------------------------------------------------------------------------*/
+    
+    /* Set the filtered recipes to default upon initial render AND every time the search input is cancellled out.
+       Filtering by search is mostly handled by click, but it is necessary to observe when the entire search query
+       is cleared. If the search is removed but category filters are still in place, set the filteredRecipes to only 
+       those filtered by category. Since the category tags being selected and unselected are already being observed in
+       a separate useEffect() in the FilterByCategories component, that useEffect() will handle updating the 
+       filteredRecipes when chosen category state changes.    */
     useEffect(
         () => {
-            if (searchTerms === "" && onlyRecipesWithTags.length === 0) {
-                setFilteredRecipes(recipes)
+            if (searchTerms === "" && chosenCategories.length === 0) {
+                setFilteredRecipes(recipesToDisplay)
             }
-            if (searchTerms === "" && onlyRecipesWithTags.length > 0) {
+            if (searchTerms === "" && chosenCategories.length > 0) {
                 setFilteredRecipes(onlyRecipesWithTags)
                 updateOnlySearchedRecipes([])
             }
         },
-        [recipes, searchTerms] 
+        [recipesToDisplay, searchTerms, onlyRecipesWithTags] 
+        /*Observe recipesToDisplay for initial render and for when display changes, observe search terms
+          to update when input is cleared, and observe onlyRecipesWithTags to update with the most current
+          recipes filtered based on category tag selection */
     )
+
+    /*-----------------------------------------------------------------------------------------------------*/
+    // Maintain 'follows' state here so that all listed recipes are updated when user is followed/unfollowed
+    // Set a state variable for the user's follows
+    const [usersFollows, updateUsersFollows] = useState([])
+
+    // Define a function to fetch the current user with their follows embedded
+    const fetchUsersFollows = () => {
+        fetch(`http://localhost:8088/users/${gastroUserObject.id}?_embed=follows`)
+                .then(response => response.json())
+                .then((userObject) => {
+                    const followArray = userObject.follows
+                    updateUsersFollows(followArray)
+                })
+    }
+
+    // Get the data for the current user with their follows embedded on initial render
+    useEffect(
+        () => {
+            fetchUsersFollows()
+        },
+        [] // When this array is empty, you are observing initial component state
+    )
+    /*-----------------------------------------------------------------------------------------------------*/
     
     // Assign a variable to useNavigate()
     const navigate = useNavigate()
     
     return <section className="pageBody">
+        <FeedChoice recipes={recipes}
+        display={display}
+        setDisplay={setDisplay}
+        updateRecipesToDisplay={updateRecipesToDisplay}
+        usersFollows={usersFollows} />
+
         <FilterBar searchTerms={searchTerms} 
         updateSearchTerms={updateSearchTerms} 
         setFilteredRecipes={setFilteredRecipes}
-        recipes={recipes}
+        recipes={recipesToDisplay}
         onlyRecipesWithTags={onlyRecipesWithTags}
         updateOnlyRecipesWithTags={updateOnlyRecipesWithTags}
         onlySearchedRecipes={onlySearchedRecipes}
-        updateOnlySearchedRecipes={updateOnlySearchedRecipes} />
+        updateOnlySearchedRecipes={updateOnlySearchedRecipes}
+        chosenCategories={chosenCategories}
+        updateChosenCategories={updateChosenCategories} />
 
         <h2>Recipe List</h2>
 
         
         <button onClick={ () => navigate("/postrecipe") }>Post a Recipe</button>
-        <RecipeFeed recipes={filteredRecipes} gastroUserObject={gastroUserObject} updateMainFeed={fetchRecipes} />
+        <RecipeFeed recipes={filteredRecipes} 
+        gastroUserObject={gastroUserObject} 
+        updateMainFeed={fetchRecipes}
+        usersFollows={usersFollows}
+        fetchUsersFollows={fetchUsersFollows} />
     </section>
 }

--- a/src/components/home/RecipeFeed.js
+++ b/src/components/home/RecipeFeed.js
@@ -2,34 +2,10 @@ import { Link, useNavigate } from "react-router-dom"
 import { DeleteRecipe } from "../PostInteraction/DeleteRecipe"
 import { FavoriteButton } from "../PostInteraction/Favorite"
 import { FollowButton } from "../PostInteraction/FollowUser"
-import { useEffect, useState } from "react"
 
-export const RecipeFeed = ({recipes, gastroUserObject, updateMainFeed}) => {
+
+export const RecipeFeed = ({recipes, gastroUserObject, updateMainFeed, usersFollows, fetchUsersFollows }) => {
     const navigate = useNavigate()
-
-    /*-----------------------------------------------------------------------------------------------------*/
-    // Maintain 'follows' state here so that all listed recipes are updated when user is followed/unfollowed
-    // Set a state variable for the user's follows
-    const [usersFollows, updateUsersFollows] = useState([])
-
-    // Define a function to fetch the current user with their follows embedded
-    const fetchUsersFollows = () => {
-        fetch(`http://localhost:8088/users/${gastroUserObject.id}?_embed=follows`)
-                .then(response => response.json())
-                .then((userObject) => {
-                    const followArray = userObject.follows
-                    updateUsersFollows(followArray)
-                })
-    }
-
-    // Get the data for the current user with their follows embedded on initial render
-    useEffect(
-        () => {
-            fetchUsersFollows()
-        },
-        [] // When this array is empty, you are observing initial component state
-    )
-    /*-----------------------------------------------------------------------------------------------------*/
 
     return <article className="recipeFeed">
     {

--- a/src/components/home/SearchRecipes.js
+++ b/src/components/home/SearchRecipes.js
@@ -39,6 +39,13 @@ export const SearchRecipes = ({ recipes, searchTerms, onlyRecipesWithTags, updat
         }
     }
 
+    /* When the display is toggled between 'allPosts' and 'postsFollowed', the recipe list will be updated.
+       If search terms are entered when this happens, this useEffect will observe that the recipe list has 
+       been updated and trigger the new recipe list to be filtered by the entered search terms. Once 
+       onlySearchedRecipes has been updated with the new recipe list, the useEffect() for filtering categories
+       will take notice and either apply additional filtering ontop of the searched recipes array if catergory
+       tags are selected, or update the filteredRecipes state with just the searched recipes if no categories
+       are selected. */
     useEffect(
         () => {
             if (searchTerms !== "") {

--- a/src/components/home/SearchRecipes.js
+++ b/src/components/home/SearchRecipes.js
@@ -1,12 +1,13 @@
+import { useEffect } from "react"
 import searchIcon from "../../assets/skillet-search-small.svg"
 
-export const SearchRecipes = ({ recipes, searchTerms, onlyRecipesWithTags, updateOnlySearchedRecipes, setFilteredRecipes, updateSearchTerms }) => {
+export const SearchRecipes = ({ recipes, searchTerms, onlyRecipesWithTags, updateOnlySearchedRecipes, setFilteredRecipes, updateSearchTerms, chosenCategories }) => {
 
     // Handle the search click
     const handleSearchClick = (evt) => {
         evt.preventDefault()
         // If there are no selected categories to filter by, filter through the original recipe list
-        if (searchTerms !== "" && onlyRecipesWithTags.length === 0) {
+        if (searchTerms !== "" && chosenCategories.length === 0) {
             const searchedRecipes = recipes.filter(recipe => {
                 // Filter by recipe title OR the authors name
                 return recipe.title.toLowerCase().includes(searchTerms.toLowerCase()) || recipe.user.name.toLowerCase().includes(searchTerms.toLowerCase())
@@ -15,7 +16,7 @@ export const SearchRecipes = ({ recipes, searchTerms, onlyRecipesWithTags, updat
             updateOnlySearchedRecipes(searchedRecipes)
             // update recipe state with search results
             setFilteredRecipes(searchedRecipes)
-        } else if (searchTerms !== "" && onlyRecipesWithTags.length > 0) { // If there are selected categories, filter through recipes already filtered by categories
+        } else if (searchTerms !== "" && chosenCategories.length > 0) { // If there are selected categories, filter through recipes already filtered by categories
             const searchedAndFilteredRecipes = onlyRecipesWithTags.filter(recipe => {
                 // Filter by recipe title OR the authors name
                 return recipe.title.toLowerCase().includes(searchTerms.toLowerCase()) || recipe.user.name.toLowerCase().includes(searchTerms.toLowerCase())
@@ -29,7 +30,7 @@ export const SearchRecipes = ({ recipes, searchTerms, onlyRecipesWithTags, updat
             updateOnlySearchedRecipes(justSearchedRecipes)
             // Set filtered recipes with current filtered results
             setFilteredRecipes(searchedAndFilteredRecipes)
-        } else if (searchTerms === "" && onlyRecipesWithTags.length > 0) { // If no search terms but categories are selected, preserve recipes filtered by categories
+        } else if (searchTerms === "" && chosenCategories.length > 0) { // If no search terms but categories are selected, preserve recipes filtered by categories
             updateOnlySearchedRecipes([])
             setFilteredRecipes(onlyRecipesWithTags)
         } else { // else, set recipe list to default
@@ -37,6 +38,21 @@ export const SearchRecipes = ({ recipes, searchTerms, onlyRecipesWithTags, updat
             setFilteredRecipes(recipes)
         }
     }
+
+    useEffect(
+        () => {
+            if (searchTerms !== "") {
+                const searchedRecipes = recipes.filter(recipe => {
+                    // Filter by recipe title OR the authors name
+                    return recipe.title.toLowerCase().includes(searchTerms.toLowerCase()) || recipe.user.name.toLowerCase().includes(searchTerms.toLowerCase())
+                })
+                // update onlySearchedRecipes state so that additional filtering can be applied ontop of searched results
+                updateOnlySearchedRecipes(searchedRecipes)
+            }
+            
+        },
+        [recipes]
+    )
 
     return <div className="searchBarContainer">
         <input id="RecipeSearchBar"


### PR DESCRIPTION
Added an interface for users to toggle between viewing all posts and only posts from users followed while preserving any selected filtering options or search input when switching views.